### PR TITLE
모락이가 금요일에 작동하지 않는 오류를 수정합니다.

### DIFF
--- a/moragi/cli/commands.py
+++ b/moragi/cli/commands.py
@@ -36,7 +36,7 @@ def send_next_menu_summary(cj_fresh_meal_store_id: int, slack_webhook_url: str):
     builder: SlackMessageBuilder
 
     is_today_friday = \
-        datetime.datetime.utcnow().astimezone(pytz.timezone('Asia/Seoul')).weekday() == Weekday.FRIDAY
+        Weekday(datetime.datetime.utcnow().astimezone(pytz.timezone('Asia/Seoul')).weekday()) == Weekday.FRIDAY
     if is_today_friday:
         week_menu = client.get_week_meal(WeekType.NEXT_WEEK)
         if not week_menu:


### PR DESCRIPTION
## Context
- https://github.com/code-yeongyu/moragi/actions/runs/4445025657/jobs/7803769399
  - 금요일 감지 분기문이 제대로 되어있지 않아 항상 금요일이 아니라고 판단하고 있음
  - 덕분에 금요일에는 로직이 제대로 동작하지 않음

## Changes
- datetime 을 가져와 `Weekday` 열거형으로 변경하여 Friday 인지 비교하도록 수정
