### PR TITLE
점심 이미지 존재여부 검사로직을 변경합니다.

### DIFF
--- a/moragi/cli/cj_fresh_meal_utils.py
+++ b/moragi/cli/cj_fresh_meal_utils.py
@@ -21,7 +21,8 @@ def get_today_meal(cj_fresh_meal_store_id: int):
 )
 def get_today_lunch_with_image(cj_fresh_meal_store_id: int):
     daily_menu = get_today_meal(cj_fresh_meal_store_id)
-    lunch_first_option_thumbnail = daily_menu.lunch[0].thumbnail_url
-    if not lunch_first_option_thumbnail:
-        raise Exception('No image found')
+    for lunch_option in daily_menu.lunch:
+        if not lunch_option.thumbnail_url:
+            raise Exception('No image found')
+
     return daily_menu.lunch


### PR DESCRIPTION
## Context
- https://github.com/code-yeongyu/moragi/actions/runs/4496456638/jobs/7911134534 처럼 이미지가 lunch 0 번 인덱스만 있고, 나머지에는 없는경우가 있는데, 이 경우 `invalid_blocks` 를 반환하고 있습니다.

## Changes
- 제곧내
